### PR TITLE
MAIA rebranding, bilingual website and MAIA v0.02 README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
-# TP App
+# MAIA – Medical AI Assistant
 
-Die **TP App** richtet sich an Patient*innen und soll den Alltag im Umgang mit Gesundheit vereinfachen.  
+**MAIA (Medical AI Assistant)** richtet sich an Patient*innen und soll den Alltag im Umgang mit Gesundheit vereinfachen.  
 Sie bietet die Möglichkeit, wichtige Informationen an einem Ort zu sammeln und zu organisieren.
+
+## MAIA v0.02 – Updates
+- Umbenennung auf **MAIA – Medical AI Assistant**.  
+- Alarm löst jetzt zuverlässig auch nach einem Neustart aus.  
+- Spracheinstellungen verbessert.  
+- Neuer Troubleshooting‑Guide.  
+- Verbesserte Chatbot‑Qualität.  
 
 ## Hauptfunktionen
 - **Dokumente & Befunde verwalten**  

--- a/index.html
+++ b/index.html
@@ -179,22 +179,7 @@
     </section>
 
     <!-- Feature 6 -->
-    <section id="feature-6" class="py-8 md:py-14 bg-white">
-      <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
-        <div class="order-2 md:order-1 relative flex justify-center">
-          <img src="GIF/Sprache.gif" alt="Sprachwahl der App" data-i18n-alt="feature_language_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
-        </div>
-        <div class="order-1 md:order-2">
-          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_language_title">Spracheinstellungen</h2>
-          <p class="mt-3 text-gray-600" data-i18n="feature_language_body">
-            Wähle zwischen Deutsch und Englisch, damit die App genauso spricht, wie du es bevorzugst.
-          </p>
-        </div>
-      </div>
-    </section>
-
-    <!-- Feature 7 -->
-    <section id="feature-7" class="py-8 md:py-14">
+    <section id="feature-6" class="py-8 md:py-14">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div>
           <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_meds_title">Medikamente verwalten</h2>
@@ -209,8 +194,8 @@
       </div>
     </section>
 
-    <!-- Feature 8 -->
-    <section id="feature-8" class="py-8 md:py-14 bg-white">
+    <!-- Feature 7 -->
+    <section id="feature-7" class="py-8 md:py-14 bg-white">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div class="order-2 md:order-1 relative flex justify-center">
           <img src="GIF/Medikamente_Alarm.gif" alt="Medikamenten‑Wecker anlegen" data-i18n-alt="feature_alarm_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
@@ -225,8 +210,8 @@
       </div>
     </section>
 
-    <!-- Feature 9 -->
-    <section id="feature-9" class="py-8 md:py-14">
+    <!-- Feature 8 -->
+    <section id="feature-8" class="py-8 md:py-14">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div>
           <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_settings_title">Einstellungen</h2>
@@ -240,8 +225,23 @@
       </div>
     </section>
 
+    <!-- Feature 9 -->
+    <section id="feature-9" class="py-8 md:py-14 bg-white">
+      <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
+        <div class="order-2 md:order-1 relative flex justify-center">
+          <img src="GIF/Sprache.gif" alt="Sprachwahl der App" data-i18n-alt="feature_language_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+        </div>
+        <div class="order-1 md:order-2">
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_language_title">Spracheinstellungen</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_language_body">
+            Wähle zwischen Deutsch und Englisch, damit die App genauso spricht, wie du es bevorzugst.
+          </p>
+        </div>
+      </div>
+    </section>
+
     <!-- Feature 10 -->
-    <section id="feature-10" class="py-8 md:py-14 bg-white">
+    <section id="feature-10" class="py-8 md:py-14">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div class="order-2 md:order-1 relative flex justify-center">
           <img src="GIF/Chat.gif" alt="Chat‑Ansicht mit Analyse" data-i18n-alt="feature_chat_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
           <button type="button" class="lang-button rounded-full px-2 py-1 text-gray-600" data-lang="de">DE</button>
           <button type="button" class="lang-button rounded-full px-2 py-1 text-gray-600" data-lang="en">EN</button>
         </div>
-        <a id="download" href="https://github.com/Y-Robin/TP_website" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-sky-600 px-4 py-2 text-white shadow hover:bg-sky-700">
+        <a id="download" href="https://github.com/Y-Robin/TP_website/releases/download/MAIA/app-debug.apk" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-sky-600 px-4 py-2 text-white shadow hover:bg-sky-700">
           <span data-i18n="nav_download">Download</span>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
             <path fill-rule="evenodd" d="M3 3a1 1 0 011-1h6a1 1 0 010 2H5v10h10V10a1 1 0 112 0v5a1 1 0 01-1 1H4a1 1 0 01-1-1V3zm11.293-.707a1 1 0 011.414 0l3 3a1 1 0 11-1.414 1.414L15 5.414V9a1 1 0 11-2 0V3a1 1 0 011-1h.293z" clip-rule="evenodd" />
@@ -93,7 +93,7 @@
         Für unlimitierten Zugriff kontaktiere bitte <a href="mailto:Yannick.Robin@web.de" class="underline">Yannick.Robin@web.de</a>.
       </p>
       <div class="mt-6 flex items-center justify-center gap-3">
-        <a href="https://github.com/Y-Robin/TP_website" target="_blank" rel="noopener noreferrer" class="rounded-xl bg-sky-600 px-6 py-3 text-white shadow hover:bg-sky-700" data-i18n="hero_primary_cta">Jetzt herunterladen</a>
+        <a href="https://github.com/Y-Robin/TP_website/releases/download/MAIA/app-debug.apk" target="_blank" rel="noopener noreferrer" class="rounded-xl bg-sky-600 px-6 py-3 text-white shadow hover:bg-sky-700" data-i18n="hero_primary_cta">Jetzt herunterladen</a>
         <a href="#features" class="rounded-xl border border-gray-300 px-6 py-3 text-gray-700 hover:bg-gray-100" data-i18n="hero_secondary_cta">Demos ansehen</a>
       </div>
     </div>
@@ -258,8 +258,8 @@
 
     <!-- Call-to-Action unten -->
     <div class="mt-6 md:mt-8 text-center">
-      <a href="https://github.com/Y-Robin/TP_website" target="_blank" rel="noopener noreferrer" class="inline-block rounded-2xl bg-sky-600 px-6 py-3 md:px-8 md:py-4 text-white shadow hover:bg-sky-700" data-i18n="cta_button">Kostenlos testen</a>
-      <p class="mt-3 text-sm text-gray-500" data-i18n="cta_note">Externer Link – führt zu GitHub. Dort bitte erneut auf „Download“ klicken.</p>
+      <a href="https://github.com/Y-Robin/TP_website/releases/download/MAIA/app-debug.apk" target="_blank" rel="noopener noreferrer" class="inline-block rounded-2xl bg-sky-600 px-6 py-3 md:px-8 md:py-4 text-white shadow hover:bg-sky-700" data-i18n="cta_button">Kostenlos testen</a>
+      <p class="mt-3 text-sm text-gray-500" data-i18n="cta_note">Externer Link – direkter APK-Download.</p>
     </div>
   </section>
 
@@ -321,7 +321,7 @@
         feature_chat_body: 'Das Herzstück der App: Analysiere deine gesammelten Daten im Chat mit OpenAI. Hinweis: Das Öffnen des Chats kann etwas dauern, da zunächst eine Zusammenfassung deiner Daten erzeugt wird.',
         feature_chat_alt: 'Chat‑Ansicht mit Analyse',
         cta_button: 'Kostenlos testen',
-        cta_note: 'Externer Link – führt zu GitHub. Dort bitte erneut auf „Download“ klicken.',
+        cta_note: 'Externer Link – direkter APK-Download.',
         footer_copyright: '© <span id="year"></span> MAIA – Medical AI Assistant',
         footer_top: 'Nach oben',
         footer_contact: 'Kontakt',
@@ -371,7 +371,7 @@
         feature_chat_body: 'The heart of the app: analyze your collected data in chat with OpenAI. Note: opening the chat can take a moment because a summary of your data is generated first.',
         feature_chat_alt: 'Chat view with analysis',
         cta_button: 'Try it for free',
-        cta_note: 'External link — takes you to GitHub. Please click “Download” there again.',
+        cta_note: 'External link — direct APK download.',
         footer_copyright: '© <span id="year"></span> MAIA – Medical AI Assistant',
         footer_top: 'Back to top',
         footer_contact: 'Contact',

--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>TP App – Offizielle Website</title>
-  <meta name="description" content="Eine Seite mit kurzen GIF-Demos, die die wichtigsten Funktionen der TP App zeigen." />
-  <meta property="og:title" content="TP App – Offizielle Website" />
-  <meta property="og:description" content="GIF-Demos zu Start, Ärzte, Transkripte, Termine, Medikamente, Wecker, Einstellungen und Chat/Analyse." />
+  <title>MAIA – Medical AI Assistant</title>
+  <meta id="meta-description" name="description" content="Eine Seite mit kurzen GIF-Demos, die die wichtigsten Funktionen von MAIA zeigen." />
+  <meta id="meta-og-title" property="og:title" content="MAIA – Medical AI Assistant" />
+  <meta id="meta-og-description" property="og:description" content="GIF-Demos zu Start, Ärzte, Transkripte, Termine, Sprachen, Medikamente, Wecker, Einstellungen und Chat/Analyse." />
   <meta property="og:type" content="website" />
   <meta name="theme-color" content="#0ea5e9" />
   <link rel="icon" href="favicon.ico" />
@@ -47,7 +47,7 @@
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5 shrink-0 mt-0.5 md:mt-0">
         <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM9 7a1 1 0 112 0 1 1 0 01-2 0zm2 2a1 1 0 10-2 0v4a1 1 0 102 0V9z" clip-rule="evenodd" />
       </svg>
-      <p class="text-sm">
+      <p class="text-sm" data-i18n="banner_text">
         Hinweis: Diese Seite zeigt kurze Demos der App. Funktionen, Design und Verfügbarkeit können sich noch ändern.
         Die Chat-Funktion und Transkription (Fotos, Audio usw.) erfolgen derzeit über die OpenAI-API. Ansonsten werden Daten lokal gespeichert.
       </p>
@@ -57,27 +57,33 @@
 
   <!-- STICKY KOPFZEILE -->
   <header class="sticky top-0 z-40 backdrop-blur bg-white/70 border-b border-gray-200">
-    <div class="max-w-6xl mx-auto px-3 sm:px-4 py-3 flex items-center justify-between">
-      <a href="#top" class="font-semibold">TP App</a>
+    <div class="max-w-6xl mx-auto px-3 sm:px-4 py-3 flex items-center justify-between gap-4">
+      <a href="#top" class="font-semibold" data-i18n="brand">MAIA – Medical AI Assistant</a>
       <nav class="hidden md:flex items-center gap-6 text-sm text-gray-600">
-        <a href="#features" class="hover:text-gray-900">Funktionen</a>
-        <a href="#download" class="hover:text-gray-900">Download</a>
+        <a href="#features" class="hover:text-gray-900" data-i18n="nav_features">Funktionen</a>
+        <a href="#download" class="hover:text-gray-900" data-i18n="nav_download">Download</a>
       </nav>
-      <a id="download" href="https://github.com/Y-Robin/TP_website" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-sky-600 px-4 py-2 text-white shadow hover:bg-sky-700">
-        Download
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
-          <path fill-rule="evenodd" d="M3 3a1 1 0 011-1h6a1 1 0 010 2H5v10h10V10a1 1 0 112 0v5a1 1 0 01-1 1H4a1 1 0 01-1-1V3zm11.293-.707a1 1 0 011.414 0l3 3a1 1 0 11-1.414 1.414L15 5.414V9a1 1 0 11-2 0V3a1 1 0 011-1h.293z" clip-rule="evenodd" />
-        </svg>
-      </a>
+      <div class="flex items-center gap-2">
+        <div class="flex items-center rounded-full border border-gray-200 bg-white p-1 text-xs">
+          <button type="button" class="lang-button rounded-full px-2 py-1 text-gray-600" data-lang="de">DE</button>
+          <button type="button" class="lang-button rounded-full px-2 py-1 text-gray-600" data-lang="en">EN</button>
+        </div>
+        <a id="download" href="https://github.com/Y-Robin/TP_website" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-2 rounded-xl bg-sky-600 px-4 py-2 text-white shadow hover:bg-sky-700">
+          <span data-i18n="nav_download">Download</span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
+            <path fill-rule="evenodd" d="M3 3a1 1 0 011-1h6a1 1 0 010 2H5v10h10V10a1 1 0 112 0v5a1 1 0 01-1 1H4a1 1 0 01-1-1V3zm11.293-.707a1 1 0 011.414 0l3 3a1 1 0 11-1.414 1.414L15 5.414V9a1 1 0 11-2 0V3a1 1 0 011-1h.293z" clip-rule="evenodd" />
+          </svg>
+        </a>
+      </div>
     </div>
   </header>
 
   <!-- HERO -->
   <section id="top" class="max-w-6xl mx-auto px-3 sm:px-4 pt-10 pb-6 md:pt-16 md:pb-10">
     <div class="text-center max-w-3xl mx-auto">
-      <h1 class="text-4xl md:text-6xl font-bold tracking-tight">Alles Wichtige auf einen Blick</h1>
-      <p class="mt-4 text-base md:text-lg text-gray-600">
-        Diese Seite zeigt die Funktionen der <strong>TP App</strong>. TP richtet sich an Patient*innen und soll den Alltag vereinfachen:
+      <h1 class="text-4xl md:text-6xl font-bold tracking-tight" data-i18n="hero_title">Alles Wichtige auf einen Blick</h1>
+      <p class="mt-4 text-base md:text-lg text-gray-600" data-i18n-html="hero_body">
+        Diese Seite zeigt die Funktionen von <strong>MAIA</strong> (Medical AI Assistant). MAIA richtet sich an Patient*innen und soll den Alltag vereinfachen:
         Arztbriefe, Medikamente, Arztgespräche und Befunde an einem Ort sammeln, Arztbesuche organisieren und per Medikamenten‑Wecker an die Einnahme erinnern.
         Das Herzstück ist die OpenAI‑Integration, mit der deine Informationen gebündelt mit ChatGPT analysiert werden können.
         <br><br>
@@ -87,8 +93,8 @@
         Für unlimitierten Zugriff kontaktiere bitte <a href="mailto:Yannick.Robin@web.de" class="underline">Yannick.Robin@web.de</a>.
       </p>
       <div class="mt-6 flex items-center justify-center gap-3">
-        <a href="https://github.com/Y-Robin/TP_website" target="_blank" rel="noopener noreferrer" class="rounded-xl bg-sky-600 px-6 py-3 text-white shadow hover:bg-sky-700">Jetzt herunterladen</a>
-        <a href="#features" class="rounded-xl border border-gray-300 px-6 py-3 text-gray-700 hover:bg-gray-100">Demos ansehen</a>
+        <a href="https://github.com/Y-Robin/TP_website" target="_blank" rel="noopener noreferrer" class="rounded-xl bg-sky-600 px-6 py-3 text-white shadow hover:bg-sky-700" data-i18n="hero_primary_cta">Jetzt herunterladen</a>
+        <a href="#features" class="rounded-xl border border-gray-300 px-6 py-3 text-gray-700 hover:bg-gray-100" data-i18n="hero_secondary_cta">Demos ansehen</a>
       </div>
     </div>
   </section>
@@ -99,14 +105,14 @@
     <section id="feature-1" class="py-8 md:py-14">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div>
-          <h2 class="text-2xl md:text-3xl font-semibold">Start der TP App</h2>
-          <p class="mt-3 text-gray-600">
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_start_title">Start der MAIA App</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_start_body">
             Beim ersten Start fragt die App nach der Berechtigung für Benachrichtigungen (erforderlich für den Medikamenten‑Wecker).
             Außerdem legst du einen Standard‑Patienten mit Name und Geburtstag an.
           </p>
         </div>
         <div class="relative flex justify-center">
-          <img src="GIF/Start_App.gif" alt="App‑Start mit Berechtigungen und Patient anlegen" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+          <img src="GIF/MAIA_Start.gif" alt="App‑Start mit Berechtigungen und Patient anlegen" data-i18n-alt="feature_start_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
         </div>
       </div>
     </section>
@@ -115,11 +121,11 @@
     <section id="feature-2" class="py-8 md:py-14 bg-white">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div class="order-2 md:order-1 relative flex justify-center">
-          <img src="GIF/Add_Arzt.gif" alt="Ärzt*innen zur Übersicht hinzufügen" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+          <img src="GIF/Add_Arzt.gif" alt="Ärzt*innen zur Übersicht hinzufügen" data-i18n-alt="feature_doctors_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
         </div>
         <div class="order-1 md:order-2">
-          <h2 class="text-2xl md:text-3xl font-semibold">Ärzt*innen hinzufügen</h2>
-          <p class="mt-3 text-gray-600">
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_doctors_title">Ärzt*innen hinzufügen</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_doctors_body">
             Nach dem Anlegen des Patienten fügst du deine behandelnden Ärzt*innen hinzu, um alles übersichtlich zu organisieren.
           </p>
         </div>
@@ -130,14 +136,14 @@
     <section id="feature-3" class="py-8 md:py-14">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div>
-          <h2 class="text-2xl md:text-3xl font-semibold">Arzt‑Details & Transkripte</h2>
-          <p class="mt-3 text-gray-600">
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_details_title">Arzt‑Details & Transkripte</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_details_body">
             Tippe auf einen Arzt, um dessen Bereich zu öffnen. Dort siehst du deine Transkripte (z. B. Arztbriefe, Untersuchungen).
             Neue Transkripte legst du oben rechts an: PDF hochladen, manuell erfassen oder ein Foto machen – alles später bearbeitbar.
           </p>
         </div>
         <div class="relative flex justify-center">
-          <img src="GIF/Arzt_Detail.gif" alt="Arzt‑Detailseite mit Transkripten" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+          <img src="GIF/Arzt_Detail.gif" alt="Arzt‑Detailseite mit Transkripten" data-i18n-alt="feature_details_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
         </div>
       </div>
     </section>
@@ -146,11 +152,11 @@
     <section id="feature-4" class="py-8 md:py-14 bg-white">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div class="order-2 md:order-1 relative flex justify-center">
-          <img src="GIF/Transcript.gif" alt="Gespräche aufnehmen und transkribieren" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+          <img src="GIF/Transcript.gif" alt="Gespräche aufnehmen und transkribieren" data-i18n-alt="feature_transcript_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
         </div>
         <div class="order-1 md:order-2">
-          <h2 class="text-2xl md:text-3xl font-semibold">Gespräche aufnehmen & transkribieren</h2>
-          <p class="mt-3 text-gray-600">
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_transcript_title">Gespräche aufnehmen & transkribieren</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_transcript_body">
             Du kannst Arztgespräche aufnehmen, anschließend transkribieren und dem passenden Arzt zuordnen.
           </p>
         </div>
@@ -161,13 +167,13 @@
     <section id="feature-5" class="py-8 md:py-14">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div>
-          <h2 class="text-2xl md:text-3xl font-semibold">Terminkalender</h2>
-          <p class="mt-3 text-gray-600">
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_calendar_title">Terminkalender</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_calendar_body">
             Der integrierte Kalender funktioniert, wie du es gewohnt bist – übersichtlich und schnell.
           </p>
         </div>
         <div class="relative flex justify-center">
-          <img src="GIF/Termin.gif" alt="Termine im integrierten Kalender" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+          <img src="GIF/Termin.gif" alt="Termine im integrierten Kalender" data-i18n-alt="feature_calendar_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
         </div>
       </div>
     </section>
@@ -176,13 +182,12 @@
     <section id="feature-6" class="py-8 md:py-14 bg-white">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div class="order-2 md:order-1 relative flex justify-center">
-          <img src="GIF/Medikamente.gif" alt="Medikamente hinzufügen und verwalten" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+          <img src="GIF/Sprache.gif" alt="Sprachwahl der App" data-i18n-alt="feature_language_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
         </div>
         <div class="order-1 md:order-2">
-          <h2 class="text-2xl md:text-3xl font-semibold">Medikamente verwalten</h2>
-          <p class="mt-3 text-gray-600">
-            Füge Medikamente hinzu und ergänze Infos aus dem Beipackzettel – per Langdruck kannst du Daten manuell eintragen oder ein Foto hochladen.
-            Nicht mehr benötigte Präparate verschiebst du in „frühere Medikamente“.
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_language_title">Spracheinstellungen</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_language_body">
+            Wähle zwischen Deutsch und Englisch, damit die App genauso spricht, wie du es bevorzugst.
           </p>
         </div>
       </div>
@@ -192,14 +197,14 @@
     <section id="feature-7" class="py-8 md:py-14">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div>
-          <h2 class="text-2xl md:text-3xl font-semibold">Medikamenten‑Wecker</h2>
-          <p class="mt-3 text-gray-600">
-            Lege Uhrzeit, Dauer und Intervall (Abstand in Tagen) fest. Wenn in den Einstellungen der Erinnerungstyp „Wecker“ gewählt ist,
-            klingelt die App zuverlässig – unabhängig von den System‑Benachrichtigungseinstellungen.
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_meds_title">Medikamente verwalten</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_meds_body">
+            Füge Medikamente hinzu und ergänze Infos aus dem Beipackzettel – per Langdruck kannst du Daten manuell eintragen oder ein Foto hochladen.
+            Nicht mehr benötigte Präparate verschiebst du in „frühere Medikamente“.
           </p>
         </div>
         <div class="relative flex justify-center">
-          <img src="GIF/Medikamente_Alarm.gif" alt="Medikamenten‑Wecker anlegen" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+          <img src="GIF/Medikamente.gif" alt="Medikamente hinzufügen und verwalten" data-i18n-alt="feature_meds_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
         </div>
       </div>
     </section>
@@ -208,12 +213,13 @@
     <section id="feature-8" class="py-8 md:py-14 bg-white">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div class="order-2 md:order-1 relative flex justify-center">
-          <img src="GIF/Settings.gif" alt="App‑Einstellungen, Dark Mode und mehrere Patient*innen" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+          <img src="GIF/Medikamente_Alarm.gif" alt="Medikamenten‑Wecker anlegen" data-i18n-alt="feature_alarm_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
         </div>
         <div class="order-1 md:order-2">
-          <h2 class="text-2xl md:text-3xl font-semibold">Einstellungen</h2>
-          <p class="mt-3 text-gray-600">
-            Aktiviere das dunkle Design, ändere den Erinnerungstyp und füge weitere Patient*innen hinzu, wenn du die App für mehrere Personen nutzt.
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_alarm_title">Medikamenten‑Wecker</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_alarm_body">
+            Lege Uhrzeit, Dauer und Intervall (Abstand in Tagen) fest. Wenn in den Einstellungen der Erinnerungstyp „Wecker“ gewählt ist,
+            klingelt die App zuverlässig – unabhängig von den System‑Benachrichtigungseinstellungen.
           </p>
         </div>
       </div>
@@ -223,40 +229,224 @@
     <section id="feature-9" class="py-8 md:py-14">
       <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
         <div>
-          <h2 class="text-2xl md:text-3xl font-semibold">Chat & Analyse mit OpenAI</h2>
-          <p class="mt-3 text-gray-600">
-            Das Herzstück der App: Analysiere deine gesammelten Daten im Chat mit OpenAI.
-            Hinweis: Das Öffnen des Chats kann etwas dauern, da zunächst eine Zusammenfassung deiner Daten erzeugt wird.
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_settings_title">Einstellungen</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_settings_body">
+            Aktiviere das dunkle Design, ändere den Erinnerungstyp und füge weitere Patient*innen hinzu, wenn du die App für mehrere Personen nutzt.
           </p>
         </div>
         <div class="relative flex justify-center">
-          <img src="GIF/Chat.gif" alt="Chat‑Ansicht mit Analyse" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+          <img src="GIF/Settings.gif" alt="App‑Einstellungen, Dark Mode und mehrere Patient*innen" data-i18n-alt="feature_settings_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+        </div>
+      </div>
+    </section>
+
+    <!-- Feature 10 -->
+    <section id="feature-10" class="py-8 md:py-14 bg-white">
+      <div class="grid md:grid-cols-2 gap-6 md:gap-8 items-center">
+        <div class="order-2 md:order-1 relative flex justify-center">
+          <img src="GIF/Chat.gif" alt="Chat‑Ansicht mit Analyse" data-i18n-alt="feature_chat_alt" class="demo-gif rounded-2xl shadow" loading="lazy" decoding="async" />
+        </div>
+        <div class="order-1 md:order-2">
+          <h2 class="text-2xl md:text-3xl font-semibold" data-i18n="feature_chat_title">Chat & Analyse mit OpenAI</h2>
+          <p class="mt-3 text-gray-600" data-i18n="feature_chat_body">
+            Das Herzstück der App: Analysiere deine gesammelten Daten im Chat mit OpenAI.
+            Hinweis: Das Öffnen des Chats kann etwas dauern, da zunächst eine Zusammenfassung deiner Daten erzeugt wird.
+          </p>
         </div>
       </div>
     </section>
 
     <!-- Call-to-Action unten -->
     <div class="mt-6 md:mt-8 text-center">
-      <a href="https://github.com/Y-Robin/TP_website" target="_blank" rel="noopener noreferrer" class="inline-block rounded-2xl bg-sky-600 px-6 py-3 md:px-8 md:py-4 text-white shadow hover:bg-sky-700">Kostenlos testen</a>
-      <p class="mt-3 text-sm text-gray-500">Externer Link – führt zu GitHub. Dort bitte erneut auf „Download“ klicken.</p>
+      <a href="https://github.com/Y-Robin/TP_website" target="_blank" rel="noopener noreferrer" class="inline-block rounded-2xl bg-sky-600 px-6 py-3 md:px-8 md:py-4 text-white shadow hover:bg-sky-700" data-i18n="cta_button">Kostenlos testen</a>
+      <p class="mt-3 text-sm text-gray-500" data-i18n="cta_note">Externer Link – führt zu GitHub. Dort bitte erneut auf „Download“ klicken.</p>
     </div>
   </section>
 
   <!-- FOOTER -->
   <footer class="border-t border-gray-200">
     <div class="max-w-6xl mx-auto px-3 sm:px-4 py-8 md:py-10 text-sm text-gray-600 flex flex-col md:flex-row items-center justify-between gap-4">
-      <p>© <span id="year"></span> TP App</p>
+      <p data-i18n-html="footer_copyright">© <span id="year"></span> MAIA – Medical AI Assistant</p>
       <div class="flex items-center gap-4">
-        <a href="#top" class="hover:underline">Nach oben</a>
-        <a href="mailto:Yannick.Robin@web.de" class="hover:underline">Kontakt</a>
-        <a href="#" class="hover:underline">Datenschutz</a>
+        <a href="#top" class="hover:underline" data-i18n="footer_top">Nach oben</a>
+        <a href="mailto:Yannick.Robin@web.de" class="hover:underline" data-i18n="footer_contact">Kontakt</a>
+        <a href="#" class="hover:underline" data-i18n="footer_privacy">Datenschutz</a>
       </div>
     </div>
   </footer>
 
   <script>
-    // Jahr automatisch setzen
-    document.getElementById('year').textContent = new Date().getFullYear();
+    const translations = {
+      de: {
+        meta_title: 'MAIA – Medical AI Assistant',
+        meta_description: 'Eine Seite mit kurzen GIF-Demos, die die wichtigsten Funktionen von MAIA zeigen.',
+        meta_og_title: 'MAIA – Medical AI Assistant',
+        meta_og_description: 'GIF-Demos zu Start, Ärzte, Transkripte, Termine, Sprachen, Medikamente, Wecker, Einstellungen und Chat/Analyse.',
+        brand: 'MAIA – Medical AI Assistant',
+        nav_features: 'Funktionen',
+        nav_download: 'Download',
+        banner_text: 'Hinweis: Diese Seite zeigt kurze Demos der App. Funktionen, Design und Verfügbarkeit können sich noch ändern. Die Chat-Funktion und Transkription (Fotos, Audio usw.) erfolgen derzeit über die OpenAI-API. Ansonsten werden Daten lokal gespeichert.',
+        hero_title: 'Alles Wichtige auf einen Blick',
+        hero_body: 'Diese Seite zeigt die Funktionen von <strong>MAIA</strong> (Medical AI Assistant). MAIA richtet sich an Patient*innen und soll den Alltag vereinfachen: Arztbriefe, Medikamente, Arztgespräche und Befunde an einem Ort sammeln, Arztbesuche organisieren und per Medikamenten‑Wecker an die Einnahme erinnern. Das Herzstück ist die OpenAI‑Integration, mit der deine Informationen gebündelt mit ChatGPT analysiert werden können.<br><br>Die App befindet sich aktuell in der Entwicklung. Du bist selbst für die Daten verantwortlich, die du übermittelst. Der Chat und die Transkription laufen derzeit über die OpenAI‑API, alle anderen Daten werden lokal gespeichert. Da wir uns im Entwicklungsstadium befinden, ist die Anzahl der Anfragen begrenzt. Für unlimitierten Zugriff kontaktiere bitte <a href="mailto:Yannick.Robin@web.de" class="underline">Yannick.Robin@web.de</a>.',
+        hero_primary_cta: 'Jetzt herunterladen',
+        hero_secondary_cta: 'Demos ansehen',
+        feature_start_title: 'Start der MAIA App',
+        feature_start_body: 'Beim ersten Start fragt die App nach der Berechtigung für Benachrichtigungen (erforderlich für den Medikamenten‑Wecker). Außerdem legst du einen Standard‑Patienten mit Name und Geburtstag an.',
+        feature_start_alt: 'App‑Start mit Berechtigungen und Patient anlegen',
+        feature_doctors_title: 'Ärzt*innen hinzufügen',
+        feature_doctors_body: 'Nach dem Anlegen des Patienten fügst du deine behandelnden Ärzt*innen hinzu, um alles übersichtlich zu organisieren.',
+        feature_doctors_alt: 'Ärzt*innen zur Übersicht hinzufügen',
+        feature_details_title: 'Arzt‑Details & Transkripte',
+        feature_details_body: 'Tippe auf einen Arzt, um dessen Bereich zu öffnen. Dort siehst du deine Transkripte (z. B. Arztbriefe, Untersuchungen). Neue Transkripte legst du oben rechts an: PDF hochladen, manuell erfassen oder ein Foto machen – alles später bearbeitbar.',
+        feature_details_alt: 'Arzt‑Detailseite mit Transkripten',
+        feature_transcript_title: 'Gespräche aufnehmen & transkribieren',
+        feature_transcript_body: 'Du kannst Arztgespräche aufnehmen, anschließend transkribieren und dem passenden Arzt zuordnen.',
+        feature_transcript_alt: 'Gespräche aufnehmen und transkribieren',
+        feature_calendar_title: 'Terminkalender',
+        feature_calendar_body: 'Der integrierte Kalender funktioniert, wie du es gewohnt bist – übersichtlich und schnell.',
+        feature_calendar_alt: 'Termine im integrierten Kalender',
+        feature_language_title: 'Spracheinstellungen',
+        feature_language_body: 'Wähle zwischen Deutsch und Englisch, damit die App genauso spricht, wie du es bevorzugst.',
+        feature_language_alt: 'Sprachwahl der App',
+        feature_meds_title: 'Medikamente verwalten',
+        feature_meds_body: 'Füge Medikamente hinzu und ergänze Infos aus dem Beipackzettel – per Langdruck kannst du Daten manuell eintragen oder ein Foto hochladen. Nicht mehr benötigte Präparate verschiebst du in „frühere Medikamente“.',
+        feature_meds_alt: 'Medikamente hinzufügen und verwalten',
+        feature_alarm_title: 'Medikamenten‑Wecker',
+        feature_alarm_body: 'Lege Uhrzeit, Dauer und Intervall (Abstand in Tagen) fest. Wenn in den Einstellungen der Erinnerungstyp „Wecker“ gewählt ist, klingelt die App zuverlässig – unabhängig von den System‑Benachrichtigungseinstellungen.',
+        feature_alarm_alt: 'Medikamenten‑Wecker anlegen',
+        feature_settings_title: 'Einstellungen',
+        feature_settings_body: 'Aktiviere das dunkle Design, ändere den Erinnerungstyp und füge weitere Patient*innen hinzu, wenn du die App für mehrere Personen nutzt.',
+        feature_settings_alt: 'App‑Einstellungen, Dark Mode und mehrere Patient*innen',
+        feature_chat_title: 'Chat & Analyse mit OpenAI',
+        feature_chat_body: 'Das Herzstück der App: Analysiere deine gesammelten Daten im Chat mit OpenAI. Hinweis: Das Öffnen des Chats kann etwas dauern, da zunächst eine Zusammenfassung deiner Daten erzeugt wird.',
+        feature_chat_alt: 'Chat‑Ansicht mit Analyse',
+        cta_button: 'Kostenlos testen',
+        cta_note: 'Externer Link – führt zu GitHub. Dort bitte erneut auf „Download“ klicken.',
+        footer_copyright: '© <span id="year"></span> MAIA – Medical AI Assistant',
+        footer_top: 'Nach oben',
+        footer_contact: 'Kontakt',
+        footer_privacy: 'Datenschutz'
+      },
+      en: {
+        meta_title: 'MAIA – Medical AI Assistant',
+        meta_description: 'A page with short GIF demos highlighting the most important MAIA features.',
+        meta_og_title: 'MAIA – Medical AI Assistant',
+        meta_og_description: 'GIF demos for start, doctors, transcripts, appointments, languages, medication, alarms, settings, and chat/analysis.',
+        brand: 'MAIA – Medical AI Assistant',
+        nav_features: 'Features',
+        nav_download: 'Download',
+        banner_text: 'Note: This page shows short demos of the app. Features, design, and availability may still change. Chat and transcription (photos, audio, etc.) currently run via the OpenAI API. Everything else is stored locally.',
+        hero_title: 'Everything important at a glance',
+        hero_body: 'This page highlights the features of <strong>MAIA</strong> (Medical AI Assistant). MAIA is designed for patients and simplifies daily life: collect medical letters, medications, doctor conversations, and findings in one place, organize appointments, and use the medication alarm for reliable reminders. The heart of the app is the OpenAI integration, which can analyze your information in ChatGPT.<br><br>The app is currently in development. You are responsible for the data you submit. Chat and transcription currently run via the OpenAI API, while everything else is stored locally. Because we are still in development, the number of requests is limited. For unlimited access, please contact <a href="mailto:Yannick.Robin@web.de" class="underline">Yannick.Robin@web.de</a>.',
+        hero_primary_cta: 'Download now',
+        hero_secondary_cta: 'View demos',
+        feature_start_title: 'Starting the MAIA app',
+        feature_start_body: 'On the first launch, the app asks for notification permission (required for the medication alarm). You also create a default patient with name and date of birth.',
+        feature_start_alt: 'App start with permissions and patient setup',
+        feature_doctors_title: 'Add doctors',
+        feature_doctors_body: 'After creating the patient, add your treating doctors so everything stays organized.',
+        feature_doctors_alt: 'Add doctors to the overview',
+        feature_details_title: 'Doctor details & transcripts',
+        feature_details_body: 'Tap a doctor to open their area. There you can see your transcripts (e.g., medical letters, examinations). New transcripts are created in the top right: upload a PDF, enter manually, or take a photo — all editable later.',
+        feature_details_alt: 'Doctor detail page with transcripts',
+        feature_transcript_title: 'Record & transcribe conversations',
+        feature_transcript_body: 'You can record doctor conversations, transcribe them, and assign them to the right doctor.',
+        feature_transcript_alt: 'Record and transcribe conversations',
+        feature_calendar_title: 'Appointment calendar',
+        feature_calendar_body: 'The built-in calendar works the way you expect — clear and fast.',
+        feature_calendar_alt: 'Appointments in the integrated calendar',
+        feature_language_title: 'Language settings',
+        feature_language_body: 'Choose between German and English so the app speaks the way you prefer.',
+        feature_language_alt: 'App language selection',
+        feature_meds_title: 'Manage medications',
+        feature_meds_body: 'Add medications and include leaflet information — with a long press you can enter data manually or upload a photo. Move no-longer-needed meds to “previous medications.”',
+        feature_meds_alt: 'Add and manage medications',
+        feature_alarm_title: 'Medication alarm',
+        feature_alarm_body: 'Set time, duration, and interval (days between doses). When the reminder type is set to “alarm” in settings, the app reliably rings regardless of system notification settings.',
+        feature_alarm_alt: 'Create a medication alarm',
+        feature_settings_title: 'Settings',
+        feature_settings_body: 'Enable dark mode, change the reminder type, and add more patients if you use the app for multiple people.',
+        feature_settings_alt: 'App settings, dark mode, and multiple patients',
+        feature_chat_title: 'Chat & analysis with OpenAI',
+        feature_chat_body: 'The heart of the app: analyze your collected data in chat with OpenAI. Note: opening the chat can take a moment because a summary of your data is generated first.',
+        feature_chat_alt: 'Chat view with analysis',
+        cta_button: 'Try it for free',
+        cta_note: 'External link — takes you to GitHub. Please click “Download” there again.',
+        footer_copyright: '© <span id="year"></span> MAIA – Medical AI Assistant',
+        footer_top: 'Back to top',
+        footer_contact: 'Contact',
+        footer_privacy: 'Privacy'
+      }
+    };
+
+    const langButtons = document.querySelectorAll('.lang-button');
+
+    const setActiveButton = (lang) => {
+      langButtons.forEach((button) => {
+        if (button.dataset.lang === lang) {
+          button.classList.add('bg-sky-600', 'text-white');
+          button.classList.remove('text-gray-600');
+          button.setAttribute('aria-pressed', 'true');
+        } else {
+          button.classList.remove('bg-sky-600', 'text-white');
+          button.classList.add('text-gray-600');
+          button.setAttribute('aria-pressed', 'false');
+        }
+      });
+    };
+
+    const applyTranslations = (lang) => {
+      const t = translations[lang];
+      if (!t) return;
+
+      document.documentElement.lang = lang;
+      document.title = t.meta_title;
+      const metaDescription = document.getElementById('meta-description');
+      const metaOgTitle = document.getElementById('meta-og-title');
+      const metaOgDescription = document.getElementById('meta-og-description');
+      if (metaDescription) metaDescription.setAttribute('content', t.meta_description);
+      if (metaOgTitle) metaOgTitle.setAttribute('content', t.meta_og_title);
+      if (metaOgDescription) metaOgDescription.setAttribute('content', t.meta_og_description);
+
+      document.querySelectorAll('[data-i18n]').forEach((el) => {
+        const key = el.getAttribute('data-i18n');
+        if (t[key]) {
+          el.textContent = t[key];
+        }
+      });
+
+      document.querySelectorAll('[data-i18n-html]').forEach((el) => {
+        const key = el.getAttribute('data-i18n-html');
+        if (t[key]) {
+          el.innerHTML = t[key];
+        }
+      });
+
+      document.querySelectorAll('[data-i18n-alt]').forEach((el) => {
+        const key = el.getAttribute('data-i18n-alt');
+        if (t[key]) {
+          el.setAttribute('alt', t[key]);
+        }
+      });
+
+      const yearEl = document.getElementById('year');
+      if (yearEl) {
+        yearEl.textContent = new Date().getFullYear();
+      }
+
+      setActiveButton(lang);
+      localStorage.setItem('maia-language', lang);
+    };
+
+    langButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        applyTranslations(button.dataset.lang);
+      });
+    });
+
+    const storedLang = localStorage.getItem('maia-language');
+    const initialLang = storedLang || (((navigator.language || '').toLowerCase().startsWith('en')) ? 'en' : 'de');
+    applyTranslations(initialLang);
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Rebrand the project from TP App to MAIA (Medical AI Assistant) and communicate the new release notes.  
- Add language support so the website is available in German and English with a simple toggle.  
- Surface the updated MAIA start demo (`MAIA_Start.gif`) and move the language demo into a dedicated language feature.  
- Fix a small JavaScript precedence bug when computing the initial language selection.

### Description
- Updated `README.md` to rename the app to **MAIA** and added a `MAIA v0.02` updates section listing alarm restart fix, language improvements, troubleshooting guide, and chatbot quality improvements.  
- Reworked `index.html` to replace TP branding with MAIA, update meta tags, swap the start GIF to `GIF/MAIA_Start.gif`, and reorganize feature GIFs to include the language demo.  
- Added a German/English toggle UI and a `translations` object with localized strings, plus logic to apply translations and persist `maia-language` to `localStorage`.  
- Fixed the `initialLang` calculation by adding parentheses to ensure correct operator precedence when deriving language from `navigator.language`.

### Testing
- Launched a local static server with `python -m http.server 8000` and verified the site served successfully.  
- Captured a full-page screenshot using a Playwright script to validate the rendered homepage and the new UI elements, which completed successfully.  
- Performed basic repository checks (`git status`) and committed the changes without errors.  
- No unit tests were required because changes are static content and frontend localization only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696141a21c5c8328802146d68669619a)