### PR TITLE
Add Impressum and Datenschutzerklärung pages and footer links

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -60,16 +60,30 @@
     </section>
 
     <section class="space-y-3 text-gray-700">
-      <h2 class="text-xl font-semibold">4. Externe Inhalte</h2>
+      <h2 class="text-xl font-semibold">4. Lokale Speicherung (LocalStorage)</h2>
       <p>
-        Für das Design wird die CSS-Bibliothek Tailwind über ein CDN eingebunden. Beim Laden dieser Ressource wird Ihre
-        IP-Adresse an den jeweiligen CDN-Anbieter übermittelt, um die Datei auszuliefern. Es werden darüber hinaus keine
-        weiteren externen Inhalte mit Tracking-Zwecken eingebunden.
+        Zur Speicherung der Sprachpräferenz wird der Eintrag <strong>maia-language</strong> im LocalStorage des Browsers
+        verwendet. Zweck ist die Anzeige der Website in der bevorzugten Sprache. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f
+        DSGVO (berechtigtes Interesse an einer nutzerfreundlichen Darstellung). Die Speicherung erfolgt bis zur manuellen
+        Löschung durch den Nutzer bzw. gemäß den Einstellungen des Browsers. Eine Weitergabe an Dritte erfolgt dadurch
+        nicht.
       </p>
     </section>
 
     <section class="space-y-3 text-gray-700">
-      <h2 class="text-xl font-semibold">5. Ihre Rechte</h2>
+      <h2 class="text-xl font-semibold">5. Externe Inhalte (CDN)</h2>
+      <p>
+        Für das Design wird <strong>Tailwind CSS (CDN)</strong> eingebunden:
+        <a href="https://cdn.tailwindcss.com" class="underline">https://cdn.tailwindcss.com</a>. Beim Abruf werden Ihre
+        IP-Adresse sowie technische Request-Daten (z. B. User-Agent, Referrer je nach Browser) an den CDN-Anbieter
+        übertragen, um die Ressourcen zur Darstellung auszuliefern. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO
+        (berechtigtes Interesse an einer effizienten, konsistenten Darstellung). Optional kann die Einbindung zukünftig
+        lokal erfolgen, um externe Requests zu vermeiden.
+      </p>
+    </section>
+
+    <section class="space-y-3 text-gray-700">
+      <h2 class="text-xl font-semibold">6. Ihre Rechte</h2>
       <p>
         Sie haben das Recht auf Auskunft über Ihre gespeicherten personenbezogenen Daten, deren Berichtigung, Löschung,
         Einschränkung der Verarbeitung sowie das Recht auf Datenübertragbarkeit. Außerdem können Sie der Verarbeitung
@@ -79,7 +93,7 @@
     </section>
 
     <section class="space-y-3 text-gray-700">
-      <h2 class="text-xl font-semibold">6. Kontakt Datenschutz</h2>
+      <h2 class="text-xl font-semibold">7. Kontakt Datenschutz</h2>
       <p>
         Bei Fragen zur Verarbeitung Ihrer personenbezogenen Daten wenden Sie sich bitte an:
         <a href="mailto:Yannick.Robin@web.de" class="underline">Yannick.Robin@web.de</a>.

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -49,6 +49,10 @@
         Empfänger der Daten ist GitHub, Inc. bzw. verbundene Unternehmen. Es kann nicht ausgeschlossen werden, dass Daten
         in Drittländer (z. B. USA) übertragen werden.
       </p>
+      <p>
+        Weitere Informationen finden Sie in der
+        <a href="https://docs.github.com/de/site-policy/privacy-policies/github-privacy-statement" class="underline">Datenschutzerklärung von GitHub</a>.
+      </p>
     </section>
 
     <section class="space-y-3 text-gray-700">
@@ -75,8 +79,9 @@
       <p>
         Für das Design wird <strong>Tailwind CSS (CDN)</strong> eingebunden:
         <a href="https://cdn.tailwindcss.com" class="underline">https://cdn.tailwindcss.com</a>. Beim Abruf werden Ihre
-        IP-Adresse sowie technische Request-Daten (z. B. User-Agent, Referrer je nach Browser) an den CDN-Anbieter
-        übertragen, um die Ressourcen zur Darstellung auszuliefern. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO
+        IP-Adresse sowie technische Request-Daten (z. B. User-Agent, Referrer je nach Browser) an den
+        Tailwind CDN (bereitgestellt über cdn.tailwindcss.com) übertragen, um die Ressourcen zur Darstellung
+        auszuliefern. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO
         (berechtigtes Interesse an einer effizienten, konsistenten Darstellung). Optional kann die Einbindung zukünftig
         lokal erfolgen, um externe Requests zu vermeiden.
       </p>

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Datenschutzerklärung – MAIA</title>
+  <meta name="description" content="Datenschutzerklärung der MAIA Demo-Seite." />
+  <meta name="theme-color" content="#0ea5e9" />
+  <link rel="icon" href="favicon.ico" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 antialiased">
+  <header class="sticky top-0 z-40 backdrop-blur bg-white/70 border-b border-gray-200">
+    <div class="max-w-6xl mx-auto px-3 sm:px-4 py-3 flex items-center justify-between gap-4">
+      <a href="index.html" class="font-semibold">MAIA – Medical AI Assistant</a>
+      <nav class="flex items-center gap-4 text-sm text-gray-600">
+        <a href="index.html#features" class="hover:text-gray-900">Funktionen</a>
+        <a href="index.html#download" class="hover:text-gray-900">Download</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-3xl mx-auto px-3 sm:px-4 py-10 md:py-14 space-y-8">
+    <header>
+      <h1 class="text-3xl md:text-4xl font-bold">Datenschutzerklärung</h1>
+      <p class="mt-2 text-gray-600">Stand: 2026-01-15</p>
+    </header>
+
+    <section class="space-y-2 text-gray-700">
+      <h2 class="text-xl font-semibold">1. Verantwortlicher</h2>
+      <p>
+        Yannick Robin<br />
+        Ockfener Straße 1<br />
+        54439 Saarburg<br />
+        Deutschland
+      </p>
+      <p>E-Mail: <a href="mailto:Yannick.Robin@web.de" class="underline">Yannick.Robin@web.de</a></p>
+    </section>
+
+    <section class="space-y-3 text-gray-700">
+      <h2 class="text-xl font-semibold">2. Hosting über GitHub Pages</h2>
+      <p>
+        Diese Website wird über GitHub Pages gehostet. Beim Aufruf werden durch GitHub als Hosting-Anbieter technische
+        Zugriffsdaten verarbeitet (z. B. IP-Adresse, Datum und Uhrzeit, angeforderte Seite), um die Auslieferung und
+        Sicherheit der Website zu gewährleisten.
+      </p>
+      <p>
+        Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an einem sicheren und stabilen Betrieb).
+        Empfänger der Daten ist GitHub, Inc. bzw. verbundene Unternehmen. Es kann nicht ausgeschlossen werden, dass Daten
+        in Drittländer (z. B. USA) übertragen werden.
+      </p>
+    </section>
+
+    <section class="space-y-3 text-gray-700">
+      <h2 class="text-xl font-semibold">3. Cookies & Tracking</h2>
+      <p>
+        Diese Website setzt derzeit keine Tracking- oder Marketing-Cookies ein. Es werden keine Analyse- oder
+        Werbedienste genutzt.
+      </p>
+    </section>
+
+    <section class="space-y-3 text-gray-700">
+      <h2 class="text-xl font-semibold">4. Externe Inhalte</h2>
+      <p>
+        Für das Design wird die CSS-Bibliothek Tailwind über ein CDN eingebunden. Beim Laden dieser Ressource wird Ihre
+        IP-Adresse an den jeweiligen CDN-Anbieter übermittelt, um die Datei auszuliefern. Es werden darüber hinaus keine
+        weiteren externen Inhalte mit Tracking-Zwecken eingebunden.
+      </p>
+    </section>
+
+    <section class="space-y-3 text-gray-700">
+      <h2 class="text-xl font-semibold">5. Ihre Rechte</h2>
+      <p>
+        Sie haben das Recht auf Auskunft über Ihre gespeicherten personenbezogenen Daten, deren Berichtigung, Löschung,
+        Einschränkung der Verarbeitung sowie das Recht auf Datenübertragbarkeit. Außerdem können Sie der Verarbeitung
+        widersprechen, sofern diese auf Art. 6 Abs. 1 lit. f DSGVO beruht. Zur Wahrnehmung Ihrer Rechte genügt eine
+        formlose Mitteilung an die oben genannten Kontaktdaten.
+      </p>
+    </section>
+
+    <section class="space-y-3 text-gray-700">
+      <h2 class="text-xl font-semibold">6. Kontakt Datenschutz</h2>
+      <p>
+        Bei Fragen zur Verarbeitung Ihrer personenbezogenen Daten wenden Sie sich bitte an:
+        <a href="mailto:Yannick.Robin@web.de" class="underline">Yannick.Robin@web.de</a>.
+      </p>
+    </section>
+  </main>
+
+  <footer class="border-t border-gray-200">
+    <div class="max-w-6xl mx-auto px-3 sm:px-4 py-8 md:py-10 text-sm text-gray-600 flex flex-col md:flex-row items-center justify-between gap-4">
+      <p>© <span id="year"></span> MAIA – Medical AI Assistant</p>
+      <div class="flex items-center gap-4">
+        <a href="index.html#top" class="hover:underline">Nach oben</a>
+        <a href="mailto:Yannick.Robin@web.de" class="hover:underline">Kontakt</a>
+        <a href="impressum.html" class="hover:underline">Impressum</a>
+        <a href="datenschutz.html" class="hover:underline">Datenschutz</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    const yearEl = document.getElementById('year');
+    if (yearEl) {
+      yearEl.textContent = new Date().getFullYear();
+    }
+  </script>
+</body>
+</html>

--- a/impressum.html
+++ b/impressum.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Impressum – MAIA</title>
+  <meta name="description" content="Impressum der MAIA Demo-Seite." />
+  <meta name="theme-color" content="#0ea5e9" />
+  <link rel="icon" href="favicon.ico" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 antialiased">
+  <header class="sticky top-0 z-40 backdrop-blur bg-white/70 border-b border-gray-200">
+    <div class="max-w-6xl mx-auto px-3 sm:px-4 py-3 flex items-center justify-between gap-4">
+      <a href="index.html" class="font-semibold">MAIA – Medical AI Assistant</a>
+      <nav class="flex items-center gap-4 text-sm text-gray-600">
+        <a href="index.html#features" class="hover:text-gray-900">Funktionen</a>
+        <a href="index.html#download" class="hover:text-gray-900">Download</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-3xl mx-auto px-3 sm:px-4 py-10 md:py-14">
+    <h1 class="text-3xl md:text-4xl font-bold">Impressum</h1>
+
+    <section class="mt-6 space-y-2 text-gray-700">
+      <h2 class="text-xl font-semibold">Angaben gemäß § 5 DDG</h2>
+      <p class="mt-2">Yannick Robin<br />
+        Ockfener Straße 1<br />
+        54439 Saarburg<br />
+        Deutschland</p>
+      <p>E-Mail: <a href="mailto:Yannick.Robin@web.de" class="underline">Yannick.Robin@web.de</a></p>
+      <p>Kein Handelsregistereintrag, keine Umsatzsteuer-ID vorhanden (Demo/Privatprojekt).</p>
+    </section>
+
+    <section class="mt-8 space-y-2 text-gray-700">
+      <h2 class="text-xl font-semibold">Haftungsausschluss</h2>
+      <p>
+        Die Inhalte dieser Website wurden mit Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und Aktualität
+        der Inhalte kann jedoch keine Gewähr übernommen werden. Externe Links wurden zum Zeitpunkt der Verlinkung
+        geprüft; auf deren Inhalte besteht kein Einfluss.
+      </p>
+    </section>
+
+    <section class="mt-8 space-y-2 text-gray-700">
+      <h2 class="text-xl font-semibold">Urheberrecht</h2>
+      <p>
+        Die auf dieser Website veröffentlichten Inhalte unterliegen dem deutschen Urheberrecht. Beiträge Dritter sind
+        als solche gekennzeichnet. Eine Vervielfältigung, Bearbeitung, Verbreitung oder Verwertung bedarf der vorherigen
+        schriftlichen Zustimmung des jeweiligen Rechteinhabers.
+      </p>
+    </section>
+  </main>
+
+  <footer class="border-t border-gray-200">
+    <div class="max-w-6xl mx-auto px-3 sm:px-4 py-8 md:py-10 text-sm text-gray-600 flex flex-col md:flex-row items-center justify-between gap-4">
+      <p>© <span id="year"></span> MAIA – Medical AI Assistant</p>
+      <div class="flex items-center gap-4">
+        <a href="index.html#top" class="hover:underline">Nach oben</a>
+        <a href="mailto:Yannick.Robin@web.de" class="hover:underline">Kontakt</a>
+        <a href="impressum.html" class="hover:underline">Impressum</a>
+        <a href="datenschutz.html" class="hover:underline">Datenschutz</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    const yearEl = document.getElementById('year');
+    if (yearEl) {
+      yearEl.textContent = new Date().getFullYear();
+    }
+  </script>
+</body>
+</html>

--- a/impressum.html
+++ b/impressum.html
@@ -29,6 +29,7 @@
         Ockfener Straße 1<br />
         54439 Saarburg<br />
         Deutschland</p>
+      <!-- Optional: Telefonnummer ergänzen, um unmittelbare Kontaktaufnahme zu erleichtern. -->
       <p>E-Mail: <a href="mailto:Yannick.Robin@web.de" class="underline">Yannick.Robin@web.de</a></p>
       <p>Kein Handelsregistereintrag, keine Umsatzsteuer-ID vorhanden (Demo/Privatprojekt).</p>
     </section>

--- a/index.html
+++ b/index.html
@@ -270,7 +270,8 @@
       <div class="flex items-center gap-4">
         <a href="#top" class="hover:underline" data-i18n="footer_top">Nach oben</a>
         <a href="mailto:Yannick.Robin@web.de" class="hover:underline" data-i18n="footer_contact">Kontakt</a>
-        <a href="#" class="hover:underline" data-i18n="footer_privacy">Datenschutz</a>
+        <a href="impressum.html" class="hover:underline" data-i18n="footer_imprint">Impressum</a>
+        <a href="datenschutz.html" class="hover:underline" data-i18n="footer_privacy">Datenschutz</a>
       </div>
     </div>
   </footer>
@@ -325,6 +326,7 @@
         footer_copyright: '© <span id="year"></span> MAIA – Medical AI Assistant',
         footer_top: 'Nach oben',
         footer_contact: 'Kontakt',
+        footer_imprint: 'Impressum',
         footer_privacy: 'Datenschutz'
       },
       en: {
@@ -375,6 +377,7 @@
         footer_copyright: '© <span id="year"></span> MAIA – Medical AI Assistant',
         footer_top: 'Back to top',
         footer_contact: 'Contact',
+        footer_imprint: 'Imprint',
         footer_privacy: 'Privacy'
       }
     };


### PR DESCRIPTION
### Motivation
- Provide legally required contact information (Impressum) and a pragmatic GDPR notice (Datenschutzerklärung) for a GitHub Pages–hosted static site in German. 
- Keep changes minimal and consistent with the existing layout and styling approach (Tailwind via CDN) and avoid adding third‑party dependencies.
- No tracking/analytics were detected, so no consent banner is needed and the privacy text should document that.

### Description
- Added `impressum.html` with the required §5 DDG contact data, short liability and copyright notes, and a consistent header/footer using the site's existing CSS approach. 
- Added `datenschutz.html` with responsible party, GitHub Pages hosting notes, legal basis, statement that no tracking/marketing cookies are used, mention of the external Tailwind CDN, user rights and contact information, and a current `Stand` date. 
- Updated `index.html` to add footer links to `impressum.html` and `datenschutz.html` and extended the inline translations with `footer_imprint`/`footer_privacy` for both `de` and `en` locales. 
- Changes are static and minimal‑invasive: no analytics libraries, no cookies set by the site itself, and no consent/banner code added.

### Testing
- Launched a local server with `python -m http.server 8000` and verified the site served successfully (succeeded). 
- Ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot of the footer to confirm the new links render (screenshot created successfully). 
- Committed the changes with `git` (commit recorded); no automated unit tests were applicable for these static content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969274682188328a56616bddaaa6170)